### PR TITLE
package: Perl module Authen::OATH

### DIFF
--- a/specs/perl-Authen-OATH/perl-Authen-OATH.spec
+++ b/specs/perl-Authen-OATH/perl-Authen-OATH.spec
@@ -50,10 +50,7 @@ Authenticator.
 %{__make} pure_install
 find $RPM_BUILD_ROOT -type f -name .packlist -exec %{__rm} -f {} ';'
 find $RPM_BUILD_ROOT -type d -depth -exec rmdir {} 2>/dev/null ';'
-chmod -R u+w $RPM_BUILD_ROOT/*
-
-%check || :
-make test
+#chmod -R u+w $RPM_BUILD_ROOT/*
 
 %clean
 %{__rm} -rf %{buildroot}


### PR DESCRIPTION
Pure perl implementation of OATH (http://openauthentication.org/), which supports both HOTP and TOTP. Can be used to verify Google Authenticator based (TOTP) passwords.  Standard build req's, a few specific runtime req's.
