### PR TITLE
Updated requires in .spec

### DIFF
--- a/specs/rubygems/rubygems.spec
+++ b/specs/rubygems/rubygems.spec
@@ -30,7 +30,7 @@ BuildArch: noarch
 BuildRequires: ruby-devel
 BuildRequires: ruby-rdoc
 
-Requires: ruby(abi) = 1.8
+Requires: ruby(abi) >= 1.8
 Requires: ruby-rdoc
 
 Provides: ruby(rubygems) = %{version}
@@ -80,6 +80,10 @@ rm -rf $RPM_BUILD_ROOT
 %{ruby_sitelib}/*
 
 %changelog
+
+* Sun Dec 11 2011 Rilindo Foster <rilindo.foster@monzell.com> - 1.3.2-3
+- Updated Requires to allow it to install if Ruby 1.9 is present, but not 1.8.
+
 * Tue Oct 11 2011 Steve Huff <shuff@vecna.org> - 1.3.2-2
 - GitHub URLs are not future-proofed, download from rubygems.org instead.
 


### PR DESCRIPTION
I ran into an issue where I accidentally compiled rubygems against 1.8 (even though I meant to compile against 1.9). I "fixed" initially by updating the requires from 1.8 to one and removing the legacy 1.8 Ruby install. Lookin at the options, it looks like that wasn't necessary - instead, it seems to be better to allow it to install if either 1.8 or 1.9 is installed. Of course, it could be better to just fork rubygems altogether and have a separate one for 1.9.
