### PR TITLE
Build of php-mcrypt

### DIFF
--- a/specs/php-mcrypt/php-mcrypt.spec
+++ b/specs/php-mcrypt/php-mcrypt.spec
@@ -3,13 +3,18 @@
 # Upstream: John Smith <imipak$sourceforge,net>
 
 %define real_name mcrypt
-%define pversion %(rpm -q php-devel --qf '%{RPMTAG_VERSION}' | tail -1)
+
+
+%{?el4:%define pversion %(rpm -q php-devel --qf '%{RPMTAG_VERSION}' | echo 4.3.9)}
+%{?el5:%define pversion %(rpm -q php-devel --qf '%{RPMTAG_VERSION}' | echo 5.1.6)}
+%{?el6:%define pversion %(rpm -q php-devel --qf '%{RPMTAG_VERSION}' | echo 5.3.3)}
+
 %define php_extdir %(php-config --extension-dir 2>/dev/null || echo %{_libdir}/php4)
 
 Summary: PHP module for using MCrypt encryption library
 Name: php-mcrypt
 Version: %{pversion}
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: GPL
 Group: Development/Languages
 URL: http://www.php.net/manual/en/book.mcrypt.php
@@ -22,6 +27,7 @@ BuildRequires: gcc
 BuildRequires: libmcrypt-devel >= 2.5.6
 BuildRequires: make
 BuildRequires: php-devel = %{pversion}
+BuildRequires: re2c
 Requires: libmcrypt >= 2.5.6
 Requires: php = %{pversion}
 
@@ -71,5 +77,8 @@ EOF
 %config(noreplace) %{_sysconfdir}/php.d/mcrypt.ini
 
 %changelog
+* Fri Mar 09 2012 Bjarne Saltbaek <arnebjarne72@hotmail.com>
+- Hardcoded PHP versions for EL4-6 to satisfy mock :-(
+
 * Fri Oct 29 2010 Steve Huff <shuff@vecna.org>
 - Initial package.


### PR DESCRIPTION
Hi Repoforge.

I have changed the php-mcrypt.spec a little so it can be build in Mock. I guess this is why it is missing in the RHEL6 repo?

BR,
Bjarne
