### PR TITLE
arj: Fix the use of a private strnlen

### DIFF
--- a/specs/arj/arj-3.10.22-private_strnlen.patch
+++ b/specs/arj/arj-3.10.22-private_strnlen.patch
@@ -1,0 +1,14 @@
+diff -up arj-3.10.22/fardata.c.orig arj-3.10.22/fardata.c
+--- arj-3.10.22/fardata.c.orig	2004-04-17 13:39:42.000000000 +0200
++++ arj-3.10.22/fardata.c	2012-04-13 20:08:49.962934526 +0200
+@@ -190,7 +190,9 @@ int msg_sprintf(char *str, FMSG *fmt, ..
+ 
+ /* Length-limited strlen() */
+ 
+-static int strnlen(const char FAR *s, int count)
++#undef strnlen
++#define strnlen arj_strnlen
++static int arj_strnlen(const char FAR *s, int count)
+ {
+  const char FAR *sc;
+ 

--- a/specs/arj/arj.spec
+++ b/specs/arj/arj.spec
@@ -4,7 +4,7 @@
 Summary: Archiver for .arj files
 Name: arj
 Version: 3.10.22
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: GPL
 Group: Applications/Archiving
 URL: http://arj.sourceforge.net/
@@ -13,6 +13,7 @@ Source0: http://dl.sf.net/sourceforge/arj/arj-%{version}.tar.gz
 Source1: unarj.sh
 Source2: unarj.1
 Patch0: http://ftp.debian.org/debian/pool/main/a/arj/arj_%{version}-2.diff.gz
+Patch1: arj-3.10.22-private_strnlen.patch
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
 BuildRequires: autoconf
@@ -31,6 +32,7 @@ provided by ARJ Software, Inc.
 for i in debian/patches/00*.patch; do
     patch -p1 < $i
 done
+%patch1 -p1
 
 %build
 pushd gnu
@@ -66,5 +68,8 @@ popd
 %exclude %{_bindir}/arj-register
 
 %changelog
+* Fri Apr 13 2012 Tom G. Christensen <jrpms@jupiterrise.com> - 3.10.22-2
+- Make sure that private strnlen is used when CUSTOM_PRINTF is defined
+
 * Tue Jun 08 2010 Dag Wieers <dag@wieers.com> - 3.10.22-1
 - Initial package. (using DAR)


### PR DESCRIPTION
This adds a patch to fix this build error encountered on el6:
fardata.c: At top level:
fardata.c:193: error: conflicting types for 'strnlen'
/usr/include/string.h:406: note: previous declaration of 'strnlen' was here

Reviewing the code it seemed to try and replace strnlen with a private version but doing so in an unsafe way, relying on the linker to pick the right version.
The patch explicitly replaces strnlen with the private version when requested by the CUSTOM_PRINTF define.
