### PR TITLE
John: Bump version to 1.7.9 and allow using the default profile

### DIFF
--- a/specs/john/john.spec
+++ b/specs/john/john.spec
@@ -1,11 +1,11 @@
 # $Id$
 # Authority: dag
 
-%define real_version jumbo-7
+%define real_version jumbo-5
 
 Summary: John the Ripper password cracker
 Name: john
-Version: 1.7.8
+Version: 1.7.9
 Release: 1%{?dist}
 License: GPLv2
 Group: Applications/System
@@ -60,7 +60,7 @@ CFLAGS="-c %{optflags} -DJOHN_SYSTEMWIDE -fomit-frame-pointer"
 %{__install} -Dp -m0755 run/john %{buildroot}%{_bindir}/john
 
 %{__install} -d -m0755 %{buildroot}%{_datadir}/john/
-%{__install} -p -m0644 run/*.chr run/password.lst %{buildroot}%{_datadir}/john/
+%{__install} -p -m0644 run/*.chr run/password.lst run/dumb16.conf run/dumb32.conf %{buildroot}%{_datadir}/john/
 
 %{__ln_s} -f john %{buildroot}%{_bindir}/unafs
 %{__ln_s} -f john %{buildroot}%{_bindir}/unique
@@ -88,6 +88,9 @@ CFLAGS="-c %{optflags} -DJOHN_SYSTEMWIDE -fomit-frame-pointer"
 %endif
 
 %changelog
+* Sun Apr 15 2012 Chris Lockfort <clockfort@csh.rit.edu> - 1.7.9-1
+- Bump version to 1.7.9 and allow using the default profile
+
 * Fri Sep 23 2011 Yury V. Zaytsev <yury@shurup.com> - 1.7.8-1
 - Bumped version to 1.7.8-jumbo-7 (Gilles Chauvin, GH-62).
 


### PR DESCRIPTION
Previously john the ripper would return semi-confusing messages when you try to use it without a specific profile.

```
[clockfort@jolt Configs]$ john ssha.txt
fopen: $JOHN/dumb16.conf: No such file or directory
[clockfort@jolt Configs]$ strace john ssha.txt 2>&1 | grep dumb16
open("/usr/share/john/dumb16.conf", O_RDONLY) = -1 ENOENT (No such file or directory)
open("$JOHN/dumb16.conf", O_RDONLY)     = -1 ENOENT (No such file or directory)
```

For some reason, even though the rpmforge-provided /etc/john.conf includes the lines:

```
# dumb-force UTF-16, in an external file
.include "$JOHN/dumb16.conf"

# dumb-force UTF-32, in an external file
.include "$JOHN/dumb32.conf"
```

these files were previously neglected from being copied in.

While correcting, I noticed a newer version available, so including that was just icing on the cake.

... this is the first time I've looked at contributing to rpmforge, so please check and point out any mistakes involving versioning, any other files that need to be edited, etc.

Thanks.
