### PR TITLE
libspf2: new package

### DIFF
--- a/specs/libspf2/libspf2.spec
+++ b/specs/libspf2/libspf2.spec
@@ -1,15 +1,21 @@
-%lib_package spf2 2
+# $Id$
+# Authority: Axel Thimm
+# Upstream: http://www.libspf2.org/
 
 Summary: An implemenation of the Sender Policy Framework
 Name: libspf2
 Version: 1.2.9
-Release: 6%{?dist}
+Release: 7%{?dist}
 License: GPL/BSD dual license
 Group: System Environment/Libraries
 URL: http://www.libspf2.org/
-Source0: http://www.libspf2.org/spf/%{name}-%{version}.tar.gz
+
+Source: http://www.libspf2.org/spf/%{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
-BuildRequires: gettext, gcc-c++
+
+BuildRequires: gettext
+BuildRequires: gcc-c++
+BuildRequires: rpm-macros-rpmforge
 
 %description
 libspf2 implements the Sender Policy Framework, a part of the SPF/SRS
@@ -18,6 +24,16 @@ Sendmail, Postfix, Exim, Zmailer and MS Exchange to check SPF records
 and make sure that the email is authorized by the domain name that it
 is coming from. This prevents email forgery, commonly used by
 spammers, scammers and email viruses/worms.
+
+%package devel
+Summary: Header files and libraries for %{name}.
+Group: Development/Libraries
+Requires: %{name} = %{version}-%{release}
+
+%description devel
+This package contains the header files and static libraries for
+%{name}. If you like to develop programs using %{name}, you will need
+to install %{name}-devel.
 
 %prep
 %setup -q
@@ -32,21 +48,37 @@ spammers, scammers and email viruses/worms.
 ac_cv_func___ns_get16=no
 export ac_cv_func___ns_get16
 %configure
-make
+make %{?_smp_mflags}
 
 %install
 rm -rf %{buildroot}
-%makeinstall includedir=%{buildroot}%{_includedir}/spf2
+%{__make} install DESTDIR="%{buildroot}"
+
+%post
+/sbin/ldconfig 2>/dev/null
+
+%postun -p /sbin/ldconfig
 
 %clean
-rm -rf %{buildroot}
+%{__rm} -rf %{buildroot}
 
 %files
-%defattr(-,root,root,-)
+%defattr(-, root, root, 0755)
 %doc README LICENSES TODO
 %{_bindir}/spf*
+%{_libdir}/*.so.*
+
+%files devel
+%defattr(-, root, root, 0755)
+%{_includedir}/spf2/*.h
+%{_libdir}/*.so
+%{_libdir}/*.a
+%{_libdir}/*.la
 
 %changelog
+* Sun May 6 2012 Kouhei Sutou <kou@clear-code.com> - 1.2.9-7
+- Imported from ATrpms.
+
 * Tue Mar  1 2011 Axel Thimm <Axel.Thimm@ATrpms.net> - 1.2.9-6
 - Update to 1.2.9.
 


### PR DESCRIPTION
http://www.libspf2.org/

libspf2 implements the Sender Policy Framework, a part of the SPF/SRS protocol pair. libspf2 is a library which allows email systems such as Sendmail, Postfix, Exim, Zmailer and MS Exchange to check SPF records and make sure that the email is authorized by the domain name that it is coming from. This prevents email forgery, commonly used by spammers, scammers and email viruses/worms.

This spec is imported from ATrpms: http://packages.atrpms.net/dist/el6/libspf2/
