### PR TITLE
Update uudeview shared library patch for newer libtool

### DIFF
--- a/specs/uudeview/uudeview-debian-patches.patch
+++ b/specs/uudeview/uudeview-debian-patches.patch
@@ -1,0 +1,372 @@
+--- uudeview-0.5.20.orig/uulib/uulib.c
++++ uudeview-0.5.20/uulib/uulib.c
+@@ -872,7 +872,10 @@
+ }
+ 
+ /*
+- * decode file first to temp file, then copy it to a final location
++ * Decode file first to temp file, then copy it to a final location.
++ * A move is preferable to a copy.  If the file is on the same
++ * partition, no copy is performed.  This is important for large
++ * files.
+  */
+ 
+ int UUEXPORT
+@@ -978,6 +981,12 @@
+     return UURET_IOERR;
+   }
+ 
++  if (rename(thefile->binfile, uugen_fnbuffer) == 0) {
++    fclose(source);
++    close(fildes);
++    goto finish_ok;
++  }
++
+   if ((target = fdopen (fildes, "wb")) == NULL) {
+     progress.action = 0;
+     UUMessage (uulib_id, __LINE__, UUMSG_ERROR,
+@@ -1042,6 +1051,8 @@
+ 	       thefile->binfile,
+ 	       strerror (uu_errno = errno));
+   }
++
++ finish_ok:
+   _FP_free (thefile->binfile);
+   thefile->binfile = NULL;
+   thefile->state  &= ~UUFILE_TMPFILE;
+@@ -1103,9 +1114,9 @@
+ 
+   while (!feof (inpfile) && 
+ 	 (uu_fast_scanning || ftell(inpfile) < maxpos)) {
+-    if (_FP_fgets (uugen_inbuffer, 511, inpfile) == NULL)
++    if (_FP_fgets (uugen_inbuffer, 1023, inpfile) == NULL)
+       break;
+-    uugen_inbuffer[511] = '\0';
++    uugen_inbuffer[1023] = '\0';
+ 
+     if (ferror (inpfile))
+       break;
+--- uudeview-0.5.20.orig/uulib/uuscan.c
++++ uudeview-0.5.20/uulib/uuscan.c
+@@ -387,10 +387,10 @@
+ 	   *attribute != '(' && *attribute != ')' &&
+ 	   *attribute != '<' && *attribute != '>' &&
+ 	   *attribute != '@' && *attribute != ',' &&
+-	   /* *attribute != ';' && */ *attribute != ':' &&
+-	   *attribute != '\\' &&*attribute != '"' &&
+-	   *attribute != '/' && /* *attribute != '[' &&
+-	   *attribute != ']' && */ *attribute != '?' &&
++	   *attribute != ';' && *attribute != ':' &&
++	   *attribute != '\\' && *attribute != '"' &&
++	   *attribute != '/' && *attribute != '[' &&
++	   *attribute != ']' && *attribute != '?' &&
+ 	   *attribute != '=' && length < 255) {
+       *ptr++ = *attribute++;
+       length++;
+--- uudeview-0.5.20.orig/uulib/uustring.h
++++ uudeview-0.5.20/uulib/uustring.h
+@@ -36,3 +36,4 @@
+ #define S_MIME_B_NOT_FOUND    35
+ #define S_MIME_MULTI_DEPTH    36
+ #define S_MIME_PART_MULTI     37
++#define S_OPEN_FILE           38
+--- uudeview-0.5.20.orig/uulib/uunconc.c
++++ uudeview-0.5.20/uulib/uunconc.c
+@@ -1311,6 +1311,12 @@
+   char *mode, *ntmp;
+   uufile *iter;
+   size_t bytes;
++#define HAVE_MKSTEMP
++#ifdef HAVE_MKSTEMP
++  int tmpfd;
++  const char *tmpprefix = "uuXXXXXX";
++  char *tmpdir = NULL;
++#endif /* HAVE_MKSTEMP */
+ 
+   if (data == NULL || data->thisfile == NULL)
+     return UURET_ILLVAL;
+@@ -1325,17 +1331,39 @@
+     return UURET_NODATA;
+ 
+   if (data->uudet == PT_ENCODED)
+-    mode = "wt";	/* open text files in text mode */
++    mode = "wtx";	/* open text files in text mode */
+   else
+-    mode = "wb";	/* otherwise in binary          */
++    mode = "wbx";	/* otherwise in binary          */
+ 
++#ifdef HAVE_MKSTEMP
++  if ((getuid()==geteuid()) && (getgid()==getegid())) {
++	  tmpdir=getenv("TMPDIR");
++  }
++
++  if (!tmpdir) {
++	  tmpdir = "/tmp";
++  }
++  data->binfile = malloc(strlen(tmpdir)+strlen(tmpprefix)+2);
++
++  if (!data->binfile) {
++#else
+   if ((data->binfile = tempnam (NULL, "uu")) == NULL) {
++#endif /* HAVE_MKSTEMP */
+     UUMessage (uunconc_id, __LINE__, UUMSG_ERROR,
+ 	       uustring (S_NO_TEMP_NAME));
+     return UURET_NOMEM;
+   }
+ 
++#ifdef HAVE_MKSTEMP
++  strcpy(data->binfile, tmpdir);
++  strcat(data->binfile, "/");
++  strcat(data->binfile, tmpprefix);
++
++  if ((tmpfd = mkstemp(data->binfile)) == -1 || 
++	  (dataout = fdopen(tmpfd, mode)) == NULL) {
++#else
+   if ((dataout = fopen (data->binfile, mode)) == NULL) {
++#endif /* HAVE_MKSTEMP */
+     /*
+      * we couldn't create a temporary file. Usually this means that TMP
+      * and TEMP aren't set
+@@ -1343,6 +1371,12 @@
+     UUMessage (uunconc_id, __LINE__, UUMSG_ERROR,
+ 	       uustring (S_WR_ERR_TARGET),
+ 	       data->binfile, strerror (uu_errno = errno));
++#ifdef HAVE_MKSTEMP
++	if (tmpfd != -1) {
++		unlink(data->binfile);
++		close(tmpfd);
++    }
++#endif /* HAVE_MKSTEMP */
+     _FP_free (data->binfile);
+     data->binfile = NULL;
+     uu_errno = errno;
+@@ -1437,6 +1471,9 @@
+ 	res = UURET_IOERR;
+ 	break;
+       }
++      UUMessage (uunconc_id, __LINE__, UUMSG_MESSAGE,
++		uustring (S_OPEN_FILE),
++		iter->data->sfname);
+       _FP_strncpy (uugen_fnbuffer, iter->data->sfname, 1024);
+     }
+ 
+@@ -1496,13 +1533,19 @@
+    */
+ 
+   if (data->uudet == BH_ENCODED && data->binfile) {
++#ifdef HAVE_MKSTEMP
++	  ntmp = malloc(strlen(tmpdir)+strlen(tmpprefix)+2);
++	  
++	  if (ntmp == NULL) {
++#else
+     if ((ntmp = tempnam (NULL, "uu")) == NULL) {
++#endif /* HAVE_MKSTEMP */
+       UUMessage (uunconc_id, __LINE__, UUMSG_ERROR,
+ 		 uustring (S_NO_TEMP_NAME));
+       progress.action = 0;
+       return UURET_NOMEM;
+     }
+-    if ((datain = fopen (data->binfile, "rb")) == NULL) {
++    if ((datain = fopen (data->binfile, "rbx")) == NULL) {
+       UUMessage (uunconc_id, __LINE__, UUMSG_ERROR,
+ 		 uustring (S_NOT_OPEN_FILE),
+ 		 data->binfile, strerror (uu_errno = errno));
+@@ -1510,12 +1553,27 @@
+       free (ntmp);
+       return UURET_IOERR;
+     }
++
++#ifdef HAVE_MKSTEMP
++    strcpy(ntmp, tmpdir);
++    strcat(ntmp, "/");
++    strcat(ntmp, tmpprefix); 
++    if ((tmpfd = mkstemp(ntmp)) == -1 ||
++		(dataout = fdopen(tmpfd, "wb")) == NULL) {
++#else
+     if ((dataout = fopen (ntmp, "wb")) == NULL) {
++#endif /* HAVE_MKSTEMP */
+       UUMessage (uunconc_id, __LINE__, UUMSG_ERROR,
+ 		 uustring (S_NOT_OPEN_TARGET),
+ 		 ntmp, strerror (uu_errno = errno));
+       progress.action = 0;
+       fclose (datain);
++#ifdef HAVE_MKSTEMP
++	  if (tmpfd != -1) {
++		  unlink(ntmp);
++		  close(tmpfd);
++	  }
++#endif /* HAVE_MKSTEMP */
+       free   (ntmp);
+       return UURET_IOERR;
+     }
+--- uudeview-0.5.20.orig/uulib/uustring.c
++++ uudeview-0.5.20/uulib/uustring.c
+@@ -107,6 +107,7 @@
+   { S_MIME_B_NOT_FOUND, "Boundary expected on Multipart message but found EOF" },
+   { S_MIME_MULTI_DEPTH, "Multipart message nested too deep" },
+   { S_MIME_PART_MULTI,  "Handling partial multipart message as plain text" },
++  { S_OPEN_FILE,        "Opened file %s" },
+ 
+   { 0, "" }
+ };
+--- uudeview-0.5.20.orig/unix/uudeview.c
++++ uudeview-0.5.20/unix/uudeview.c
+@@ -443,18 +443,46 @@
+   FILE *target;
+   size_t bytes;
+   int res;
++#define HAVE_MKSTEMP
++#ifdef HAVE_MKSTEMP
++  int tmpfd;
++  const char *tmpprefix = "uuXXXXXX";
++  char *tmpdir = NULL;
++#endif /* HAVE_MKSTEMP */
+ 
+   if (stdinput) {
+     fprintf (stderr, "proc_stdin: cannot process stdin twice\n");
+     return 0;
+   }
+ 
++#ifdef HAVE_MKSTEMP
++  if ((getuid()==geteuid()) && (getgid()==getegid())) {
++	tmpdir=getenv("TMPDIR");
++  }
++
++  if (!tmpdir) {
++	tmpdir = "/tmp";
++  }
++  stdfile = malloc(strlen(tmpdir)+strlen(tmpprefix)+2);
++
++  if (!stdfile) {
++#else
+   if ((stdfile = tempnam (NULL, "uu")) == NULL) {
++#endif
+     fprintf (stderr, "proc_stdin: cannot get temporary file\n");
+     return 0;
+   }
+ 
+-  if ((target = fopen (stdfile, "wb")) == NULL) {
++#ifdef HAVE_MKSTEMP
++  strcpy(stdfile, tmpdir);
++  strcat(stdfile, "/");
++  strcat(stdfile, tmpprefix);
++
++  if ((tmpfd = mkstemp(stdfile)) == -1 ||
++	  (target = fdopen(tmpfd, "wbx")) == NULL) {
++#else
++  if ((target = fopen (stdfile, "wbx")) == NULL) {
++#endif
+     fprintf (stderr, "proc_stdin: cannot open temp file %s for writing: %s\n",
+ 	     stdfile, strerror (errno));
+     _FP_free (stdfile);
+@@ -657,9 +685,6 @@
+     else switch (*(argv[number] + 1)) {
+     case '\0':
+       interact = 0;
+-      if (overwrite == 0) {
+-	overwrite = 1;
+-      }
+       proc_stdin ();
+       break;
+     case 'a':
+@@ -699,10 +724,7 @@
+ 	fprintf (stderr, "WARNING: cannot interact when reading from stdin\n");
+       }
+       else {
+-	interact  = (*argv[number] == '+') ? 1 : 0;
+-	if (overwrite == 0 && *argv[number] == '-') {
+-	  overwrite = 1;
+-	}
++	interact = (*argv[number] == '+') ? 1 : 0;
+       }
+       break;
+     case 'm':
+@@ -773,6 +795,8 @@
+       break;
+     }
+   }
++  if (overwrite == 0 && interact == 0 && autoren == 0)
++    overwrite = 1;
+ 
+   return 1;
+ }
+--- uudeview-0.5.20.orig/man/uudeview.1
++++ uudeview-0.5.20/man/uudeview.1
+@@ -164,6 +164,16 @@
+ verbosity. Normally, the program prints some status messages
+ while reading the input files, which can be very helpful if something
+ should go wrong. Use if these messages disturb you.
++Disables progress bars. See
++.B -n
++option.
++.TP
++.B -v
++(disables Verbosity) Disables verbose messages, i.e. notes are not
++displayed, but does not remove warnings and errors. Is not as quiet as
++the
++.B -q
++(Quiet) option.
+ .TP
+ .B -n
+ No progress bars. Normally, UUDeview prints ASCII bars crawling up
+--- uudeview-0.5.20.orig/tcl/xdeview
++++ uudeview-0.5.20/tcl/xdeview
+@@ -59,8 +59,8 @@
+ # MIME configuration
+ #
+ 
+-ifndef MIMEGlobalTypes	""
+-ifndef MIMEGlobalCap	""
++ifndef MIMEGlobalTypes	"/etc/mime.types"
++ifndef MIMEGlobalCap	"/etc/mailcap"
+ if { ! [ catch { set env(HOME) } ] } {
+     ifndef MIMELocalTypes	$env(HOME)/.mime.types
+     ifndef MIMELocalCap		$env(HOME)/.mailcap
+--- uudeview-0.5.20.orig/man/uuwish.1
++++ uudeview-0.5.20/man/uuwish.1
+@@ -0,0 +1,45 @@
++.\" Copyright (c) 1999  Roland Rosenfeld <roland@spinnaker.de>
++.\" changes Copyright (c) 2001  Chris Hanson <cph@debian.org>
++.\"               
++.\" This program is free software; you can redistribute it and/or modify
++.\" it under the terms of the GNU General Public License as published by
++.\" the Free Software Foundation; either version 2 of the License, or
++.\" (at your option) any later version.
++.\" 
++.\" This program is distributed in the hope that it will be useful,
++.\" but WITHOUT ANY WARRANTY; without even the implied warranty of
++.\" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++.\" GNU General Public License for more details.
++.\" 
++.\" You should have received a copy of the GNU General Public License
++.\" along with this program; if not, write to the Free Software
++.\" Foundation, Inc.,59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
++.\"
++.\" This manual page is written especially for Debian Linux.
++.\"
++.TH UUWISH 1 "February 2001" "Debian Project" "Debian GNU/Linux"
++.SH NAME
++uuwish \- A minimal wish extended by the UU commands
++.SH SYNOPSIS
++.B uuwish
++is a minimal
++.BR wish (1)
++extended by the UU commands that are available in
++.BR uudeview (1)
++and
++.BR uuenview (1).
++.B uuwish
++isn't meant to be called directly; it is a Tcl/Tk script interpreter,
++which is meant to be used by
++.BR xdeview (1).
++.SH "SEE ALSO"
++.BR xdeview (1),
++.BR uudeview (1),
++.BR uuenview (1),
++.BR wish (1).
++.SH AUTHOR
++.B uuwish
++was written by Frank Pilhofer <fp@informatik.uni-frankfurt.de>.
++.PP
++This manual page was written by Roland Rosenfeld <roland@debian.org>,
++for the Debian GNU/Linux system (but may be used by others).

--- a/specs/uudeview/uudeview-shared.patch
+++ b/specs/uudeview/uudeview-shared.patch
@@ -1,6 +1,40 @@
---- uudeview-0.5.18/uulib/Makefile.in.orig	Mon Mar 11 10:15:46 2002
-+++ uudeview-0.5.18/uulib/Makefile.in	Sun May 12 14:15:40 2002
-@@ -40,9 +40,13 @@
+diff -up uudeview-0.5.20/tcl/Makefile.in.shared uudeview-0.5.20/tcl/Makefile.in
+--- uudeview-0.5.20/tcl/Makefile.in.shared	2001-06-04 18:26:57.000000000 +0200
++++ uudeview-0.5.20/tcl/Makefile.in	2012-03-28 15:07:05.875796084 +0200
+@@ -95,8 +95,8 @@ new:		clean
+ 	rm -f uuwish
+ 	make all
+ 
+-uuwish:		$(OBJ) ../uulib/libuu.a
+-	$(CC) -o $@ $(OBJ) -L../uulib -luu $(LIBS)
++uuwish:		$(OBJ) ../uulib/libuu.la
++	$(CC) -o $@ $(OBJ) -L../uulib/.libs -luu $(LIBS)
+ 
+ xdeview:
+ 	chmod 755 $@
+diff -up uudeview-0.5.20/unix/Makefile.in.shared uudeview-0.5.20/unix/Makefile.in
+--- uudeview-0.5.20/unix/Makefile.in.shared	2001-06-04 18:26:58.000000000 +0200
++++ uudeview-0.5.20/unix/Makefile.in	2012-03-28 15:07:05.874678652 +0200
+@@ -114,11 +114,11 @@ new:		clean
+ 	rm -f uudeview uuenview
+ 	make all
+ 
+-uudeview:	$(UUDEVIEW_OBJ) ../uulib/libuu.a
+-	$(CC) -o $@ $(UUDEVIEW_OBJ) -L../uulib -luu $(LIBS)
++uudeview:	$(UUDEVIEW_OBJ) ../uulib/libuu.la
++	$(CC) -o $@ $(UUDEVIEW_OBJ) -L../uulib/.libs -luu $(LIBS)
+ 
+-uuenview:	$(UUENVIEW_OBJ) ../uulib/libuu.a
+-	$(CC) -o $@ $(UUENVIEW_OBJ) -L../uulib -luu $(LIBS)
++uuenview:	$(UUENVIEW_OBJ) ../uulib/libuu.la
++	$(CC) -o $@ $(UUENVIEW_OBJ) -L../uulib/.libs -luu $(LIBS)
+ 
+ .c.o:
+ 	$(CC) -c $(CFLAGS) -I../uulib $(VDEF) $<
+diff -up uudeview-0.5.20/uulib/Makefile.in.shared uudeview-0.5.20/uulib/Makefile.in
+--- uudeview-0.5.20/uulib/Makefile.in.shared	2002-03-11 10:15:46.000000000 +0100
++++ uudeview-0.5.20/uulib/Makefile.in	2012-03-28 15:11:38.946670413 +0200
+@@ -40,9 +40,13 @@ PATCH	=	@PATCH@
  VDEF	=	-DVERSION=\"$(VERSION)\" -DPATCH=\"$(PATCH)\"
  #
  
@@ -15,7 +49,7 @@
  
  #
  # make stuff
-@@ -51,11 +55,11 @@
+@@ -51,11 +55,11 @@ UULIB_OBJ	=	${UULIB_SOURCE:.c=.o}
  .SUFFIXES:
  .SUFFIXES: .c .o
  
@@ -29,7 +63,7 @@
  
  distclean:	clean
  	rm -f config.status config.cache config.log Makefile config.h
-@@ -64,25 +68,28 @@
+@@ -64,25 +68,28 @@ distclean:	clean
  realclean:	distclean
  
  new:		clean
@@ -54,14 +88,14 @@
 -uustring.o:	uustring.c uudeview.h uuint.h uustring.h config.h
 -fptools.o:	fptools.c fptools.h config.h
 +libuu.la:	$(UULIB_OBJ)
-+	libtool $(CC) -o libuu.la $(LDFLAGS) $(UULIB_OBJ) -rpath /usr/lib
++	libtool --mode=link $(CC) -o libuu.la $(LDFLAGS) $(UULIB_OBJ) -rpath /usr/lib
 +
 +%.lo : %.c
-+	libtool $(CC) -c $(CFLAGS) $(VDEF) $<
++	libtool --mode=compile $(CC) -c $(CFLAGS) $(VDEF) $<
 +
 +install:	libuu.la
 +	install -d $(DESTDIR)$(libdir) $(DESTDIR)$(includedir)
-+	libtool install libuu.la $(DESTDIR)$(libdir)
++	libtool --mode=install install libuu.la $(DESTDIR)$(libdir)
 +	install uudeview.h fptools.h $(DESTDIR)$(includedir)
 +
 +uuencode.lo:	uuencode.c uudeview.h uuint.h uustring.h fptools.h config.h
@@ -75,33 +109,3 @@
  
  uustring.h:	uustring.c
  	awk -f uustring.awk < uustring.c > uustring.h
---- uudeview-0.5.18/unix/Makefile.in.orig	Mon Jun  4 18:26:58 2001
-+++ uudeview-0.5.18/unix/Makefile.in	Sun May 12 14:22:29 2002
-@@ -114,10 +114,10 @@
- 	rm -f uudeview uuenview
- 	make all
- 
--uudeview:	$(UUDEVIEW_OBJ) ../uulib/libuu.a
--	$(CC) -o $@ $(UUDEVIEW_OBJ) -L../uulib -luu $(LIBS)
-+uudeview:	$(UUDEVIEW_OBJ) ../uulib/libuu.la
-+	$(CC) -o $@ $(UUDEVIEW_OBJ) -L../uulib/.libs -luu $(LIBS)
- 
--uuenview:	$(UUENVIEW_OBJ) ../uulib/libuu.a
--	$(CC) -o $@ $(UUENVIEW_OBJ) -L../uulib -luu $(LIBS)
-+uuenview:	$(UUENVIEW_OBJ) ../uulib/libuu.la
-+	$(CC) -o $@ $(UUENVIEW_OBJ) -L../uulib/.libs -luu $(LIBS)
- 
- .c.o:
---- uudeview-0.5.18/tcl/Makefile.in.orig	Mon Jun  4 18:26:57 2001
-+++ uudeview-0.5.18/tcl/Makefile.in	Sun May 12 14:26:14 2002
-@@ -95,8 +95,8 @@
- 	rm -f uuwish
- 	make all
- 
--uuwish:		$(OBJ) ../uulib/libuu.a
--	$(CC) -o $@ $(OBJ) -L../uulib -luu $(LIBS)
-+uuwish:		$(OBJ) ../uulib/libuu.la
-+	$(CC) -o $@ $(OBJ) -L../uulib/.libs -luu $(LIBS)
- 
- xdeview:
- 	chmod 755 $@

--- a/specs/uudeview/uudeview.spec
+++ b/specs/uudeview/uudeview.spec
@@ -11,7 +11,7 @@
 Summary: Smart decoder for uuencode, xxencode, Base64 and BinHex
 Name: uudeview
 Version: 0.5.20
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: GPL
 Group: Applications/File
 URL: http://www.fpx.de/fp/Software/UUDeview/
@@ -19,6 +19,7 @@ URL: http://www.fpx.de/fp/Software/UUDeview/
 Source: http://www.fpx.de/fp/Software/UUDeview/download/uudeview-%{version}.tar.gz
 Patch0: uudeview-shared.patch
 Patch1: uudeview-latex-psfig-deprecated.patch
+Patch2: uudeview-debian-patches.patch
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
 BuildRequires: autoconf, libtool
@@ -57,6 +58,7 @@ you will need to install %{name}-devel.
 %setup
 %patch0 -p1
 %patch1 -p1
+%patch2 -p1
 
 %build
 %{__libtoolize} --force --copy
@@ -82,7 +84,7 @@ you will need to install %{name}-devel.
 %doc HISTORY IAFA-PACKAGE README* doc uudeview.lsm
 %doc %{_mandir}/man1/uudeview.1*
 %doc %{_mandir}/man1/uuenview.1*
-#%{_bindir}/minews
+%{_bindir}/minews
 %{_bindir}/uudeview
 %{_bindir}/uuenview
 %{_libdir}/libuu.so.*
@@ -103,6 +105,10 @@ you will need to install %{name}-devel.
 %exclude %{_libdir}/libuu.la
 
 %changelog
+* Wed Mar 28 2012 Tom G. Christensen <tgc@statsbiblioteket.dk> - 0.5.20-2
+- Fix shared library generation for newer libtool
+- Add patches from Debian (via Fedora)
+
 * Thu Nov 29 2007 Dries Verachtert <dries@ulyssis.org> - 0.5.20-1
 - Added patch for the latex docs, thanks to Nicolas Thierry-Mieg.
 


### PR DESCRIPTION
Additionally pull in the Debian patchset used in the Fedora package.

This fixes the build error on el6.

Build tested on el4/i386, el5/x86_64, el6/x86_64.

Worked for my purposes on el6.
