### PR TITLE
Updating eggdrop to 1.6.21 (latest stable)

### DIFF
--- a/specs/eggdrop/eggdrop.spec
+++ b/specs/eggdrop/eggdrop.spec
@@ -10,7 +10,7 @@
 
 Summary: IRC bot
 Name: eggdrop
-Version: 1.6.19
+Version: 1.6.21
 Release: 1%{?dist}
 License: GPL
 Group: Applications/Internet
@@ -18,7 +18,7 @@ URL: http://www.eggheads.org/
 
 Source: ftp://ftp.eggheads.org/pub/eggdrop/GNU/stable/eggdrop%{version}.tar.bz2
 #Patch0: eggdrop1.6.17-lib64.patch
-Patch1: eggdrop1.6.17-64bit-fixes.patch
+#Patch1: eggdrop1.6.17-64bit-fixes.patch
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
 BuildRequires: tcl, perl
@@ -36,7 +36,7 @@ privileged users and let them gain ops, etc.
 %prep
 %setup -n %{name}%{version}
 #patch0 -p1 -b .lib64
-%patch1 -p1 -b .64bit-fixes
+#%patch1 -p1 -b .64bit-fixes
 
 # _smp_mflags removed, compile fails on multiprocessor system  
 %build
@@ -70,6 +70,9 @@ perl -pi -e 's|/path/to/executable/eggdrop|%{_libdir}/eggdrop/eggdrop|' eggdrop.
 %{_libdir}/eggdrop/
 
 %changelog
+* Mon Jun 18 2012 Shawn Sterling <shawn@systemtemplar.org> - 1.6.21-1
+- Updated to release 1.6.21.
+
 * Sun Apr 20 2008 Dries Verachtert <dries@ulyssis.org> - 1.6.19-1
 - Updated to release 1.6.19.
 


### PR DESCRIPTION
this will require downloading the latest source:

ftp://ftp.eggheads.org/pub/eggdrop/source/1.6/eggdrop1.6.21.tar.bz2
