### PR TITLE
Changed fish shell to the new fish fish fork v2.0.0 b2

### DIFF
--- a/specs/fish/fish.spec
+++ b/specs/fish/fish.spec
@@ -9,7 +9,7 @@ Summary: Friendly interactive shell
 Name: fish
 Version: 2.0.0r2
 Release: 1%{?dist}
-License: GPL
+License: GPLv2
 Group: System Environment/Shells
 URL: http://ridiculousfish.com/shell
 


### PR DESCRIPTION
Changed to use the new fishfish fork of the unmaintained fish, using version 2.0.0 bete r2.

See http://ridiculousfish.com/shell/ (new)
and http://fishshell.com/ (unmaintained)
