### PR TITLE
K4dirstat 2.7.4

### DIFF
--- a/specs/k4dirstat/k4dirstat-2.7.4-desktop.patch
+++ b/specs/k4dirstat/k4dirstat-2.7.4-desktop.patch
@@ -1,0 +1,27 @@
+From ee6a73f0b9400955dbb12277d12d007de415a2fa Mon Sep 17 00:00:00 2001
+From: Evgueni Souleimanov <esoule@100500.ca>
+Date: Thu, 16 May 2013 21:12:33 -0400
+Subject: [PATCH] k4dirstat.desktop: terminate Categories list with semicolon
+
+Terminate Categories list with a semicolon, because it is a string list.
+Fixes the error reported by "desktop-file-validate" utility on el6:
+
+"error: value "Utility" for string list key "Categories" in group
+"Desktop Entry" does not have a semicolon (';') as trailing character"
+---
+ src/k4dirstat.desktop | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/k4dirstat.desktop b/src/k4dirstat.desktop
+index 4b75c2e..192a9de 100644
+--- a/src/k4dirstat.desktop
++++ b/src/k4dirstat.desktop
+@@ -12,4 +12,4 @@ Comment[de]=Verzeichnisstatistik und Platzverbrauch
+ Comment[hu]=Könyvtárstatisztikák és szabad hely
+ Terminal=false
+ MimeType=inode/directory;
+-Categories=Utility
++Categories=Utility;
+-- 
+1.7.11.3
+

--- a/specs/k4dirstat/k4dirstat-snapshot.sh
+++ b/specs/k4dirstat/k4dirstat-snapshot.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-version=2.7.0
-gitversion=6c0a9e6
+version=2.7.4
+gitversion=33ed79e
 
-git clone http://grumpypenguin.org/~josh/kdirstat.git
-git archive --format=tar --prefix=k4dirstat-${version}/ --remote=kdirstat ${gitversion} | bzip2 --best -cf - > k4dirstat-${version}.tar.bz2
+git clone  https://bitbucket.org/jeromerobert/k4dirstat.git  ./k4dirstat
+git  --git-dir=./k4dirstat/.git archive --format=tar --prefix=k4dirstat-${version}/ ${gitversion} | bzip2 --best -cf - > k4dirstat-${version}.tar.bz2

--- a/specs/k4dirstat/k4dirstat.spec
+++ b/specs/k4dirstat/k4dirstat.spec
@@ -1,17 +1,19 @@
-%define preversion 20101010git6c0a9e6
+%define preversion 20130311git33ed79e
 
 Name:           k4dirstat
-Version:        2.7.0
-Release:        0.9.%{preversion}%{?dist}
+Version:        2.7.4
+Release:        0.12.%{preversion}%{?dist}
 Summary:        Graphical Directory Statistics for Used Disk Space
 
 Group:          Applications/System
 License:        GPLv2 and LGPLv2
-URL:            http://grumpypenguin.org/
+URL:            http://bitbucket.org/jeromerobert/k4dirstat
 
 Source0:        %{name}-%{version}.tar.bz2
 #script to get snapshot of k4dirstat
 Source1:        k4dirstat-snapshot.sh
+
+Patch100:       k4dirstat-2.7.4-desktop.patch
 
 BuildRequires:  kdebase4-devel
 
@@ -27,8 +29,12 @@ It can also help you clean up used space.
 
 K4DirStat is the port to KDE4.
 
+This is Jerome Robert's fork of Joshua Hodosh kdirstat KDE4 port
+(http://grumpypenguin.org).
+
 %prep
 %setup -q
+%patch100 -p1 -b .desktop-file
 
 %build
 
@@ -68,17 +74,23 @@ fi
 
 %files
 %defattr(-,root,root,-)
-%doc AUTHORS  COPYING  COPYING.LIB  CREDITS  README
+%doc AUTHORS  COPYING  COPYING.LIB  CREDITS  TODO
 %{_kde4_bindir}/k4dirstat
 %{_kde4_bindir}/kdirstat
 %{_kde4_datadir}/applications/kde4/k4dirstat.desktop
 %{_kde4_datadir}/config.kcfg/k4dirstat.kcfg
 %{_kde4_docdir}/HTML/en/k4dirstat/
 %{_kde4_iconsdir}/hicolor/*/apps/k4dirstat.png
+%{_kde4_iconsdir}/hicolor/*/apps/k4dirstat.svgz
 %{_kde4_appsdir}/k4dirstat
 
 
 %changelog
+* Thu May 16 2013 Evgueni Souleimanov <esoule@100500.ca> - 2.7.4-0.12.20130311git33ed79e
+- Update to version 2.7.4 git 33ed79e from Jerome Robert's fork
+  at http://bitbucket.org/jeromerobert/k4dirstat
+- Fix desktop file, so that it passes desktop-file-validate
+
 * Thu Feb 14 2013 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 2.7.0-0.9.20101010git6c0a9e6
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_19_Mass_Rebuild
 


### PR DESCRIPTION
KDirStat (KDE Directory Statistics) is a utility program that sums up
disk usage for directory trees - very much like the Unix 'du' command.
It can also help you clean up used space.

K4DirStat is the port to KDE4.

This is Jerome Robert's fork of Joshua Hodosh kdirstat KDE4 port
(http://grumpypenguin.org).

I propose to add k4dirstat to rpmforge for CentOS 6. CentOS 5 has KDE 3.5 and the appropriate package for it is kdirstat.
