### PR TITLE
puppet: update to 2.7.22

### DIFF
--- a/specs/puppet/puppet.spec
+++ b/specs/puppet/puppet.spec
@@ -13,7 +13,7 @@
 
 Summary: Network tool for managing many disparate systems
 Name: puppet
-Version: 2.7.21
+Version: 2.7.22
 Release: 1%{?dist}
 License: Apache License 2.0
 Group: System Environment/Base
@@ -289,6 +289,9 @@ fi
 %{__rm} -rf %{buildroot}
 
 %changelog
+* Tue Jul 02 2013 Tom G. Christensen <tgc@statsbiblioteket.dk> - 2.7.22-1
+- Updated to release 2.7.22.
+
 * Fri Apr 05 2013 Tom G. Christensen <tgc@statsbiblioteket.dk> - 2.7.21-1
 - Updated to release 2.7.21.
 


### PR DESCRIPTION
Update puppet to 2.7.22.
This fixes:
CVE-2013-3567 Unauthenticated Remote Code Execution Vulnerability.
