### PR TITLE
fixed perl-Math-TrulyRandom.spec file so package builds fine on el6

### DIFF
--- a/specs/perl-Math-TrulyRandom/perl-Math-TrulyRandom.spec
+++ b/specs/perl-Math-TrulyRandom/perl-Math-TrulyRandom.spec
@@ -48,9 +48,9 @@ find %{buildroot} -name .packlist -exec %{__rm} {} \;
 %defattr(-, root, root, 0755)
 %doc MANIFEST README
 %doc %{_mandir}/man?/*
-%{_libdir}/perl5/vendor_perl/*/*-linux-thread-multi/*
 %dir %{perl_vendorarch}/Math/
 %{perl_vendorarch}/Math/TrulyRandom.pm
+%doc %{perl_vendorarch}/Math/TrulyRandom.pod
 %dir %{perl_vendorarch}/auto/Math/
 %{perl_vendorarch}/auto/Math/TrulyRandom/
 


### PR DESCRIPTION
According to this thread on CentOS 6 forums: 

https://www.centos.org/modules/newbb/viewtopic.php?forum=56&topic_id=38446

installing mon from repoforge repo fails:

```
Error: Package: mon-1.2.0-2.el6.rf.x86_64 (rpmforge)
           Requires: perl(Math::TrulyRandom)
 You could try using --skip-broken to work around the problem
 You could try running: rpm -Va --nofiles --nodigest
```

Looks like perl-Math-TrulyRandom package was never built correctly due to SPEC file issue. Buildlog shows errors: http://pkgs.repoforge.org/perl-Math-TrulyRandom/_buildlogs/perl-Math-TrulyRandom-1.0-1.2.el6.rf.x86_64.ko.log.gz .
I corrected the SPEC file, so now perl-Math-TrulyRandom builds fine on both CentOS 6 x86_64 and i686.
