### PR TITLE
puppet: update to 2.7.23

### DIFF
--- a/specs/puppet/puppet.spec
+++ b/specs/puppet/puppet.spec
@@ -13,7 +13,7 @@
 
 Summary: Network tool for managing many disparate systems
 Name: puppet
-Version: 2.7.22
+Version: 2.7.23
 Release: 1%{?dist}
 License: Apache License 2.0
 Group: System Environment/Base
@@ -289,6 +289,9 @@ fi
 %{__rm} -rf %{buildroot}
 
 %changelog
+* Tue Oct 22 2013 Tom G. Christensen <swpkg@statsbiblioteket.dk> 2.7.23-1
+- Updated to release 2.7.23.
+
 * Tue Jul 02 2013 Tom G. Christensen <tgc@statsbiblioteket.dk> - 2.7.22-1
 - Updated to release 2.7.22.
 


### PR DESCRIPTION
A long overdue update.

Fixes two CVEs:
CVE-2013-4761 (resource_type Remote Code Execution Vulnerability)
CVE-2013-4956 (Puppet Module Permissions Vulnerability)

http://docs.puppetlabs.com/puppet/2.7/reference/release_notes.html#security-fixes
