### PR TITLE
python-h5py: initial commit of version 2.2.0.

### DIFF
--- a/specs/python-h5py/python-h5py.spec
+++ b/specs/python-h5py/python-h5py.spec
@@ -1,0 +1,53 @@
+%define python_sitearch %(%{__python} -c 'from distutils import sysconfig; print sysconfig.get_python_lib(1)')
+%define real_name h5py
+
+Summary: A Pythonic interface to the HDF5 binary data format
+Name: python-%{real_name}
+Version: 2.2.0
+Release: 1%{?dist}
+License: BSD
+Group: Development/Libraries/Python
+URL: http://www.h5py.org/
+
+Source: http://h5py.googlecode.com/files/h5py-2.2.0.tar.gz
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+
+BuildRequires:  gcc
+BuildRequires:  python >= 2.6
+BuildRequires:  hdf5-devel >= 1.8.3
+BuildRequires:  python-devel >= 2.6
+BuildRequires:  numpy
+Requires:  python >= 2.6
+Requires:  hdf5 >= 1.8.3
+Requires:  hdf5-devel >= 1.8.3
+Requires:  numpy
+
+%description
+H5py provides a simple, robust read/write interface to HDF5 data from Python.
+Existing Python and Numpy concepts are used for the interface; for example,
+datasets on disk are represented by a proxy class that supports slicing, and
+has dtype and shape attributes. HDF5 groups are presented using a dictionary
+metaphor, indexed by name.
+
+%prep
+%setup -n %{real_name}-%{version}
+
+%build
+%{__python} setup.py build
+
+%install
+%{__rm} -rf %{buildroot}
+%{__python} setup.py install --root="%{buildroot}" --prefix="%{_prefix}"
+
+%clean
+%{__rm} -rf %{buildroot}
+
+%files
+%defattr(-, root, root, 0755)
+%doc README.rst
+%{python_sitearch}/%{real_name}/
+%{python_sitearch}/*.egg-info
+
+%changelog
+* Thu Nov 28 2013 Chris LeBlanc <crleblanc@gmail.com> - 2.2.0-1
+- Initial package (basic build, no support for parallel I/O)

--- a/specs/python-h5py/python-h5py.spec
+++ b/specs/python-h5py/python-h5py.spec
@@ -3,13 +3,13 @@
 
 Summary: A Pythonic interface to the HDF5 binary data format
 Name: python-%{real_name}
-Version: 2.2.0
+Version: 2.2.1
 Release: 1%{?dist}
 License: BSD
 Group: Development/Libraries/Python
 URL: http://www.h5py.org/
 
-Source: http://h5py.googlecode.com/files/h5py-2.2.0.tar.gz
+Source: http://h5py.googlecode.com/files/h5py-2.2.1.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
 BuildRequires:  gcc
@@ -49,5 +49,8 @@ metaphor, indexed by name.
 %{python_sitearch}/*.egg-info
 
 %changelog
+* Tue Jan 28 2014 Chris LeBlanc <crleblanc@gmail.com> - 2.2.1-1
+- Updated to version 2.2.1.  See h5py.org for more info.
+
 * Thu Nov 28 2013 Chris LeBlanc <crleblanc@gmail.com> - 2.2.0-1
 - Initial package (basic build, no support for parallel I/O)

--- a/specs/python-h5py/python-h5py.spec
+++ b/specs/python-h5py/python-h5py.spec
@@ -20,7 +20,7 @@ BuildRequires:  numpy
 Requires:  python >= 2.6
 Requires:  hdf5 >= 1.8.3
 Requires:  hdf5-devel >= 1.8.3
-Requires:  numpy
+Requires:  numpy >= 1.4.1
 
 %description
 H5py provides a simple, robust read/write interface to HDF5 data from Python.


### PR DESCRIPTION
Hello,

Would you please have a look at my proposed specfile for the python-h5py package?  H5py requires Python 2.6, so won't run on anything older than RHEL6.

I've installed the newly created h5py rpm on a clean RHEL6 (64 bit) system and it worked nicely.  I ran the h5py tests, and saw a single failing test.  This test also fails when installing h5py using 'pip', so I do think it's related to the rpm packaging.

This is my first pull request to repoforge, so please let me know if there's anything I should change.

Thanks,
Chris