### PR TITLE
Update DBD::AnyData to 0.110 for compatibility with DBI 1.622

### DIFF
--- a/specs/perl-DBD-AnyData/perl-DBD-AnyData.spec
+++ b/specs/perl-DBD-AnyData/perl-DBD-AnyData.spec
@@ -9,7 +9,7 @@
 
 Summary: Interface to data in many formats and from many sources
 Name: perl-DBD-AnyData
-Version: 0.09
+Version: 0.110
 Release: 1%{?dist}
 License: Artistic/GPL
 Group: Applications/CPAN
@@ -58,6 +58,9 @@ find %{buildroot} -name .packlist -exec %{__rm} {} \;
 %{perl_vendorlib}/DBD/AnyData.pm
 
 %changelog
+* Thu Nov 28 2013 Travers Carter <tcarter@noggin.com.au> - 0.110-1
+- Updated to release 0.110.
+
 * Fri Nov 09 2007 Dag Wieers <dag@wieers.com> - 0.09-1
 - Updated to release 0.09.
 


### PR DESCRIPTION
DBD::AnyData 0.09 is not compatible with DBI 1.622:

Can't call method "params" on unblessed reference at /usr/lib64/perl5/vendor_perl/5.8.8/x86_64-linux-thread-multi/DBI/DBD/SqlEngine.pm line 785

Upgrading to 0.110 resolves the problem.
