### PR TITLE
circket: fix crontab permission, x86_64 library directory names (/usr/lib64/cricket)  and use directory names from SPEC file

### DIFF
--- a/specs/cricket/cricket.apache
+++ b/specs/cricket/cricket.apache
@@ -1,14 +1,14 @@
-Alias /cricket/images   /usr/lib/cricket/www/images
-Alias /cricket          /usr/lib/cricket/www/cgi
+Alias /cricket/images   @imgdir@
+Alias /cricket          @cgidir@
 
-<Directory /usr/lib/cricket/www/cgi>
+<Directory @cgidir@>
     Options +ExecCGI
     Order Deny,Allow
     Deny from all
     Allow from localhost
 </Directory>
 
-<Directory /usr/lib/cricket/www/images>
+<Directory @imgdir@>
     Order Deny,Allow
     Deny from all
     Allow from localhost

--- a/specs/cricket/cricket.cron
+++ b/specs/cricket/cricket.cron
@@ -1,4 +1,4 @@
 MAILTO=root
-*/5 * * * * cricket /usr/lib/cricket/collect-subtrees -cf=/etc/cricket/subtree-sets normal #>/dev/null 2>&1
-*/5 * * * * apache find /var/cache/cricket -type f -mmin +10 | xargs -r rm
+*/5 * * * * cricket @appdir@/collect-subtrees -cf=@etcdir@/subtree-sets normal #>/dev/null 2>&1
+*/5 * * * * apache find @cachedir@ -type f -mmin +10 -print0 | xargs -0 -r rm
 


### PR DESCRIPTION
Hi,

I fixed some issues with cricket RPM (I'm using x86_64 and CentOS 6.4)
- crontab file should be writable only for owner. With previous config cron reported:
  crond[1452]: (root) BAD FILE MODE (/etc/cron.d/cricket)
- in x86_64 the library directory %{_libdir} is /usr/lib64 not /usr/lib. I removed this and other directories configured in SPEC file from config files and set them during installation. I didn't touch any cricket own files however (except cricket-conf.pl which listed /usr/lib)

I also removed trailing slashes from directory names and fixed one place where slash was missing between two directory names (worked because of trailing slash).

cheers,
## 

Cougar
