### PR TITLE
Fix rrdcached socket permissions

### DIFF
--- a/specs/rrdtool/rrdcached.sysconfig
+++ b/specs/rrdtool/rrdcached.sysconfig
@@ -1,3 +1,3 @@
 # Settings for rrdcached
-OPTIONS="-l unix:/var/rrdtool/rrdcached/rrdcached.sock -s rrdcached -m 664 -b /var/rrdtool/rrdcached"
+OPTIONS="-m 664 -l unix:/var/rrdtool/rrdcached/rrdcached.sock -s rrdcached -b /var/rrdtool/rrdcached"
 RRDC_USER=rrdcached


### PR DESCRIPTION
-m mode option affects the following UNIX socket addresses, ie it has to be before -l option(s)
