### PR TITLE
Ganglia metric lifetime fix

### DIFF
--- a/specs/ganglia/ganglia.spec
+++ b/specs/ganglia/ganglia.spec
@@ -3,7 +3,7 @@
 Summary: Ganglia Distributed Monitoring System
 Name: ganglia
 Version: 3.1.7
-Release: 3%{?dist}
+Release: 4%{?dist}
 License: BSD
 Group: Applications/Internet
 URL: http://ganglia.sourceforge.net/
@@ -14,6 +14,7 @@ Source0: http://dl.sf.net/project/ganglia/ganglia%20monitoring%20core/%{version}
 Patch0: diskusage-pcre.patch
 Patch1: setuserid-fix.patch
 Patch2: diskmetrics.patch
+Patch3: gmond-dmax.patch
 Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
 BuildRequires: apr-devel >= 1
@@ -103,6 +104,7 @@ programmers can use to build scalable cluster or grid applications
 %patch0 -p1
 %patch1 -p1
 %patch2 -p1
+%patch3 -p1
 ## Hey, those shouldn't be executable...
 chmod -x lib/*.{h,x}
 

--- a/specs/ganglia/gmond-dmax.patch
+++ b/specs/ganglia/gmond-dmax.patch
@@ -1,0 +1,19 @@
+diff -uNr ganglia-3.1.7/gmond/gmond.c ganglia-3.1.7-patch/gmond/gmond.c
+--- ganglia-3.1.7/gmond/gmond.c	2010-02-17 12:05:39.000000000 +0100
++++ ganglia-3.1.7-patch/gmond/gmond.c	2014-02-15 15:16:29.000000000 +0100
+@@ -1575,13 +1575,14 @@
+     }
+   
+   len = apr_snprintf(metricxml, 1024,
+-          "<METRIC NAME=\"%s\" VAL=\"%s\" TYPE=\"%s\" UNITS=\"%s\" TN=\"%d\" TMAX=\"%d\" DMAX=\"0\" SLOPE=\"%s\">\n",
++          "<METRIC NAME=\"%s\" VAL=\"%s\" TYPE=\"%s\" UNITS=\"%s\" TN=\"%d\" TMAX=\"%d\" DMAX=\"%d\" SLOPE=\"%s\">\n",
+               metricName,
+               gmetric_value_to_str(&(val->message_u.v_message)),
+               data->message_u.f_message.Ganglia_metadata_msg_u.gfull.metric.type,
+               data->message_u.f_message.Ganglia_metadata_msg_u.gfull.metric.units,
+               (int)((now - val->last_heard_from) / APR_USEC_PER_SEC),
+               data->message_u.f_message.Ganglia_metadata_msg_u.gfull.metric.tmax,
++              data->message_u.f_message.Ganglia_metadata_msg_u.gfull.metric.dmax,
+               slope_to_cstr(data->message_u.f_message.Ganglia_metadata_msg_u.gfull.metric.slope));
+ 
+   if (metricName) free(metricName);


### PR DESCRIPTION
Version 3.1.7 of ganglia-gmond erroneously sets the lifetime of every metric to infinity (DMAX=0) regardless of what was requested.
