### PR TITLE
Fix perl math truly random build

### DIFF
--- a/specs/perl-Math-TrulyRandom/perl-Math-TrulyRandom.spec
+++ b/specs/perl-Math-TrulyRandom/perl-Math-TrulyRandom.spec
@@ -9,7 +9,7 @@
 Summary: Perl interface to a truly random number generator function
 Name: perl-Math-TrulyRandom
 Version: 1.0
-Release: 1.2%{?dist}
+Release: 1.3%{?dist}
 License: distributable
 Group: Applications/CPAN
 URL: http://search.cpan.org/dist/Math-TrulyRandom/
@@ -55,6 +55,9 @@ find %{buildroot} -name .packlist -exec %{__rm} {} \;
 %{perl_vendorarch}/auto/Math/TrulyRandom/
 
 %changelog
+* Sun Aug 30 2014 Vasyl "Br0ziliy" Kaigorodov <vkaigoro@redhat.com> - 1.2-1.3
+- Fixed .spec file to build correctly on .el6
+
 * Sat Apr 08 2006 Dries Verachtert <dries@ulyssis.org> - 1.0-1.2
 - Rebuild for Fedora Core 5.
 


### PR DESCRIPTION
Following up on #291 with version number increased, and updated %changelog.
...
According to this thread on CentOS 6 forums:

https://www.centos.org/modules/newbb/viewtopic.php?forum=56&topic_id=38446

installing mon from repoforge repo fails:

```
Error: Package: mon-1.2.0-2.el6.rf.x86_64 (rpmforge)
           Requires: perl(Math::TrulyRandom)
 You could try using --skip-broken to work around the problem
 You could try running: rpm -Va --nofiles --nodigest
```

Looks like perl-Math-TrulyRandom package was never built correctly due to SPEC file issue. Buildlog shows errors: http://pkgs.repoforge.org/perl-Math-TrulyRandom/_buildlogs/perl-Math-TrulyRandom-1.0-1.2.el6.rf.x86_64.ko.log.gz .
I corrected the SPEC file, so now perl-Math-TrulyRandom builds fine on both CentOS 6 x86_64 and i686.
